### PR TITLE
Add Scala 2.11/2.12 cross-building

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 lazy val commonSettings = Seq(
-  version := "0.1.3-SNAPSHOT",
+  version := "0.1.3",
   name := "likelib",
   organization := "com.stabletechs",
   scalaVersion := "2.12.1",

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,11 @@
 lazy val commonSettings = Seq(
-  version := "0.1.2",
+  version := "0.1.3-SNAPSHOT",
   name := "likelib",
   organization := "com.stabletechs",
-  scalaVersion := "2.11.8",
+  scalaVersion := "2.12.1",
+  crossScalaVersions := Seq("2.11.8", "2.12.1"),
   libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-  libraryDependencies += "com.lihaoyi" %% "utest" % "0.3.1" % "test",
+  libraryDependencies += "com.lihaoyi" %% "utest" % "0.4.5" % "test",
   testFrameworks += new TestFramework("utest.runner.Framework")
 )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.9")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.15")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 


### PR DESCRIPTION
This pull request adds cross-compilation on Scala 2.11 and 2.12, rather than just 2.11. I had to update the Scala.js and uTest dependencies to be compatible with 2.12.

Feel free to use any of this if you want to publish a Scala 2.12 version of this lib!